### PR TITLE
Remove file after touch

### DIFF
--- a/snotes
+++ b/snotes
@@ -140,6 +140,15 @@ blame|b)
 changed|c)
     file="changed:${select% *}"
     ;;
+remove|rm)
+    [ ! -e "${select% *}" ] && die "file '`pwd`/${select% *}' doesn't exists"
+    while [ "$rmselect" != "NO" -a "$rmselect" != "YES" ]; do
+        rmselect=`echo -e 'NO\nYES' | dmenu ${DMENU_ARGS} -i -p "Do you want to remove '${select% *}' note?"`
+        [ -z "$rmselect" ] && exit 0
+    done
+    [ "$rmselect" = "NO" ] && exit 0
+    file="remove:${select% *}"
+    ;;
 *)
     file="note:${select}"
 esac

--- a/snotes-open
+++ b/snotes-open
@@ -104,18 +104,24 @@ commit)
 changed)
     changed "${1##*:}"
     ;;
+remove)
+    snotes_file="${1##*:}"
+    snotes_file_flags=deleted
+    ;;
 *)
     die "unknown prefix '${1%:*}'"
     ;;
 esac
 
-${SNOTES_EDITOR} "$snotes_file"
+if [ "$snotes_file_flags" != "deleted" ]; then
+    ${SNOTES_EDITOR} "$snotes_file"
 
-if [ "${SNOTES_CLEANUP}" = "yes" -a "$snotes_file_flags" != "temp" -a -f "$snotes_file" ]; then
-    cleanup "$snotes_file"
+    if [ "${SNOTES_CLEANUP}" = "yes" -a "$snotes_file_flags" != "temp" -a -f "$snotes_file" ]; then
+        cleanup "$snotes_file"
+    fi
+
+    [ ! -s "$snotes_file" -a -z "$snotes_file_flags" ] && snotes_file_flags=deleted
 fi
-
-[ ! -s "$snotes_file" -a -z "$snotes_file_flags" ] && snotes_file_flags=deleted
 
 case "$snotes_file_flags" in
 created)


### PR DESCRIPTION
This fix some emacs' features. For example if you open an empty .gpg
file in emacs, it will prompt an error. But, if you open a non-existent
.gpg file it will assume that it's a new file, so you don't get an
error.
