### PR TITLE
Remove file after touch [v2]

### DIFF
--- a/snotes-open
+++ b/snotes-open
@@ -34,6 +34,10 @@ cd "${SNOTES_DB}"
 unset snotes_file
 unset snotes_file_flags
 
+cancreate(){
+    [ ! -e "$1" -o -f "$1" ] && (touch "$1" && rm -f "$1") > /dev/null 2>&1
+}
+
 blame(){
     local tmp
     tmp="`newtemp`"
@@ -88,7 +92,7 @@ case "${1%:*}" in
 note)
     snotes_file="${1##*:}"
     if [ ! -f "$snotes_file" ]; then
-        touch "$snotes_file" && snotes_file_flags=created || die "could not create file '`pwd`/$snotes_file'"
+        cancreate "$snotes_file" && snotes_file_flags=created || die "could not create file '`pwd`/$snotes_file'"
     fi
     ;;
 blame)
@@ -106,8 +110,9 @@ changed)
 esac
 
 ${SNOTES_EDITOR} "$snotes_file"
+[ ! -f "$snotes_file" -a "$snotes_file_flags" = "created" ] && die "file '`pwd`/$snotes_file' didn't created"
 
-if [ "${SNOTES_CLEANUP}" = "yes" -a "$snotes_file_flags" != "temp" ]; then
+if [ "${SNOTES_CLEANUP}" = "yes" -a "$snotes_file_flags" != "temp" -a -f "$snotes_file" ]; then
     cleanup "$snotes_file"
 fi
 


### PR DESCRIPTION
This fix some emacs' features. For example if you open an empty .gpg
file in emacs, it will prompt an error. But, if you open a non-existent
.gpg file it will assume that it's a new file, so you don't get an
error.
